### PR TITLE
Migrated toggle API to v9

### DIFF
--- a/j2toggl_core/toggl_api_client.py
+++ b/j2toggl_core/toggl_api_client.py
@@ -145,7 +145,7 @@ class TogglClient:
             wl.activity = "Other"
 
     def __make_reports_api_url(self, relative_url: str):
-        return "{0}//reports/api/v2/{1}".format(self.__toggl_url, relative_url)
+        return "{0}/reports/api/v2/{1}".format(self.__toggl_url, relative_url)
 
     def __make_api_uri(self, relative_url: str):
-        return "{0}/api/v8/{1}".format(self.__toggl_url, relative_url)
+        return "{0}/api/v9/{1}".format(self.__toggl_url, relative_url)


### PR DESCRIPTION
Toggl API v8 was [deprecated](https://engineering.toggl.com/changes/2022/10/01/api-v8-deprecation/index.html) and stopped working.